### PR TITLE
Wrap callback in extern "C" block.

### DIFF
--- a/object-lifetime/object_lifetime.cpp
+++ b/object-lifetime/object_lifetime.cpp
@@ -787,6 +787,8 @@ static void* get_parent(cl_kernel kernel) {
   return NULL;
 }
 
+extern "C" {
+
   /* OpenCL 1.0 */
 static CL_API_ENTRY cl_int CL_API_CALL clGetPlatformIDs_wrap(
     cl_uint num_entries,
@@ -3683,6 +3685,8 @@ static CL_API_ENTRY cl_int CL_API_CALL clSetContextDestructorCallback_wrap(
     pfn_notify,
     user_data);
 }
+
+} // extern "C"
 
 static void _init_dispatch(void) {
   dispatch.clGetPlatformIDs = &clGetPlatformIDs_wrap;


### PR DESCRIPTION
This is probably me being pedantic, but the dispatch table is defined inside an `extern "C"` block, while the callbacks were not. This shouldn't have been a problem, but this feels cleaner.

I created a pull request (rather than a suggestion) in order to have the CI validate the change.

CI ran: see https://github.com/Kerilk/OpenCL-Layers/actions/runs/2282819938 and https://github.com/Kerilk/OpenCL-Layers/actions/runs/2282819937

edit: if this looks good, I will make a separate pull-request for the other layers